### PR TITLE
Optimization: don't create temporary strings when marshalling, just write directly to the IO

### DIFF
--- a/src/redis/connection.cr
+++ b/src/redis/connection.cr
@@ -32,30 +32,30 @@ class Redis::Connection
   end
 
   def queue(request : Request)
-    @io << marshal(request)
+    marshal(request, @io)
   end
 
   def flush
     @io.flush
   end
 
-  def marshal(arg : Int)
-    ":#{arg}\r\n"
+  def marshal(arg : Int, io)
+    io << ":" << arg << "\r\n"
   end
 
-  def marshal(arg : String)
-    "$#{arg.size}\r\n#{arg}\r\n"
+  def marshal(arg : String, io)
+    io << "$" << arg.size << "\r\n" << arg << "\r\n"
   end
 
-  def marshal(arg : Array(RedisValue))
-    result = StringIO.new
-    result << "*#{arg.length}\r\n"
-    arg.each { |element| result << marshal(element) }
-    result.to_s
+  def marshal(arg : Array(RedisValue), io)
+    io << "*" << arg.length << "\r\n"
+    arg.each do |element|
+      marshal(element, io)
+    end
   end
 
-  def marshal(arg : Nil)
-    "$-1\r\n"
+  def marshal(arg : Nil, io)
+    io << "$-1\r\n"
   end
 
   # Receives n responses with the expected content "QUEUED".


### PR DESCRIPTION
First of all, I really like your Redis client :-) 

I actually started writing one [here](http://github.com/manastech/crystal_redis) some time ago for a basic app that I wrote, but I just did the basics. Plus, I don't know well the Redis protocol, the pipeline mode and all of the strategies, so it's really good that you started from scratch and modelled everything very well. Having top-quality libraries, with good documentation, like yours, helps Crystal a lot. Thank you! I'll soon erase the other project as yours is by far superior ;-)

This pull request optimizes the IO logic. One rule of thumb for making efficient code is not creating temporary short-lived objects. IO in Crystal is optimized for that case. For example, instead of having just a `#to_s` method, types have a `#to_s(IO)` method to write directly to an IO. This makes it possible to, for example, output a number to a console without allocating any memory. This isn't possible in most of the other languages out there.

With this small optimization (small in code size ;-)) I went from 297933 operations per second to 484958, in pipeline mode.

(As a side note, instead of documenting return types in the docs, you can use return types, for example:

```crystal
# Not so good:

# Returns an Int32
def foo
  1
end

# Better:

# the code speaks for itself
def foo : Int32
end
```

This feature was added in 0.7.0 so don't worry if you didn't know about it. It's also not documented anywhere yet, but hopefully I'll finish the docs this week or the next one)
