### PR TITLE
Change shard name from `crystal-redis` to `redis`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: crystal-redis
+name: redis
 version: 1.2.0
 
 authors:


### PR DESCRIPTION
The shard name should be the name you use for requiring the shard (`require "redis"`), otherwise shards complains. I have this `shard.yml`:

```yaml
name: coco
version: 0.1.0

authors:
  - name <email@example.com>

description: |
  Short description of coco

dependencies:
  redis:
    github: stefanwille/crystal-redis
    version: ~> 1.2.1
```

When I run `crystal deps` it tells me:

```
Error: shard name (crystal-redis) doesn't match dependency name (redis)
```

If I change the dependency name to `crystal-redis` then I can't require it, because if I do `require "crystal-redis"` it doesn't work because there's no `crystal-redis.cr` in this repository. So the simplest change is to change the name to `redis`.