### PR TITLE
Fix SCAN with match

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -15,6 +15,13 @@ private def convert_to_string_array(a)
   a.map { |item| item.to_s }
 end
 
+# Same as `sort` except sorting feature
+private def array(a) : Array(String)
+  (a as Array(Redis::RedisValue)).map(&.to_s)
+rescue
+  raise "Cannot convert to Array(Redis::RedisValue): #{a.class}"
+end
+
 describe Redis do
   describe ".new" do
     it "connects to default host and port" do
@@ -295,6 +302,35 @@ describe Redis do
       new_cursor = new_cursor as String
       new_cursor.to_i.should be > 0
       keys.is_a?(Array).should be_true
+    end
+
+    it "#scan with match" do
+      redis.set("scan.match1", "1")
+      redis.set("scan.match2", "2")
+      new_cursor, keys = redis.scan(0, "scan.match*")
+      new_cursor = new_cursor as String
+      new_cursor.to_i.should be > 0
+      keys.is_a?(Array).should be_true
+      # Here `keys.size` should be 0 or 1 or 2, but I don't know how to test it.
+    end
+
+    it "#scan with match and count" do
+      redis.set("scan.match1", "1")
+      redis.set("scan.match2", "2")
+      new_cursor, keys = redis.scan(0, "scan.match*", 1)
+      new_cursor = new_cursor as String
+      new_cursor.to_i.should be > 0
+      keys.is_a?(Array).should be_true
+      # Here `keys.size` should be 0 or 1, but I don't know how to test it.
+    end
+
+    it "#scan with match and count at once" do
+      redis.set("scan.match1", "1")
+      redis.set("scan.match2", "2")
+      # assumes that current redis instance has at most 10M entries
+      new_cursor, keys = redis.scan(0, "scan.match*", 10_000_000)
+      new_cursor.should eq("0")
+      array(keys).sort.should eq(["scan.match1", "scan.match2"])
     end
   end
 
@@ -577,6 +613,34 @@ describe Redis do
       new_cursor.should eq("0")
       sort(keys).should eq(["a", "b"])
     end
+
+    it "#sscan with match" do
+      redis.del("myset")
+      redis.sadd("myset", "foo", "bar", "foo2", "foo3")
+      new_cursor, keys = redis.sscan("myset", 0, "foo*", 2)
+      new_cursor = new_cursor as String
+      keys.is_a?(Array).should be_true
+      array(keys).size.should be > 0
+    end
+
+    it "#sscan with match and count" do
+      redis.del("myset")
+      redis.sadd("myset", "foo", "bar", "baz")
+      new_cursor, keys = redis.sscan("myset", 0, "*a*", 1)
+      new_cursor = new_cursor as String
+      new_cursor.to_i.should be > 0
+      keys.is_a?(Array).should be_true
+      array(keys).size.should be > 0
+    end
+
+    it "#sscan with match and count at once" do
+      redis.del("myset")
+      redis.sadd("myset", "foo", "bar", "baz")
+      new_cursor, keys = redis.sscan("myset", 0, "*a*", 10)
+      new_cursor.should eq("0")
+      keys.is_a?(Array).should be_true
+      array(keys).sort.should eq(["bar", "baz"])
+    end
   end
 
   describe "hashes" do
@@ -655,6 +719,31 @@ describe Redis do
       new_cursor, keys = redis.hscan("myhash", 0)
       new_cursor.should eq("0")
       keys.should eq(["field1", "a", "field2", "b"])
+    end
+
+    it "#hscan with match" do
+      redis.del("myhash")
+      redis.hmset("myhash", {"foo": "a", "bar": "b"})
+      new_cursor, keys = redis.hscan("myhash", 0, "f*")
+      new_cursor.should eq("0")
+      keys.is_a?(Array).should be_true
+      # {foo:a} is matched, and redis returns the key and val as a single list
+      array(keys).should eq(["foo", "a"])
+    end
+
+    # pending: hscan doesn't handle COUNT strictly
+    # it "#hscan with match and count" do
+    # end
+
+    it "#hscan with match and count at once" do
+      redis.del("myhash")
+      redis.hmset("myhash", {"foo": "a", "bar": "b", "baz": "c"})
+      new_cursor, keys = redis.hscan("myhash", 0, "*a*", 1024)
+      new_cursor.should eq("0")
+      keys.is_a?(Array).should be_true
+      # extract odd elements for keys because hscan returns (key, val) as a single list
+      keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+      keys.sort.should eq(["bar", "baz"])
     end
 
     it "#hsetnx" do
@@ -764,6 +853,32 @@ describe Redis do
       new_cursor, keys = redis.zscan("myzset", 0)
       new_cursor.should eq("0")
       keys.should eq(["one", "1", "two", "2", "three", "3"])
+    end
+
+    it "#zscan with match" do
+      redis.del("myzset")
+      redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+      new_cursor, keys = redis.zscan("myzset", 0, "t*")
+      new_cursor.should eq("0")
+      keys.is_a?(Array).should be_true
+      # extract odd elements for keys because zscan returns (key, val) as a single list
+      keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+      keys.should eq(["two", "three"])
+    end
+
+    # pending: zscan doesn't handle COUNT strictly
+    # it "#zscan with match and count" do
+    # end
+
+    it "#zscan with match and count at once" do
+      redis.del("myzset")
+      redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+      new_cursor, keys = redis.zscan("myzset", 0, "t*", 1024)
+      new_cursor.should eq("0")
+      keys.is_a?(Array).should be_true
+      # extract odd elements for keys because zscan returns (key, val) as a single list
+      keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+      keys.should eq(["two", "three"])
     end
 
     it "#zrevrank" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -493,15 +493,13 @@ class Redis
     #
     # ```
     # redis.scan(0)
+    # redis.scan(0, "foo*")
+    # redis.scan(0, "foo*", 1024)
     # ```
     def scan(cursor, match = nil, count = nil)
       q = ["SCAN", cursor.to_s]
-      if match
-        q << match
-        if count
-          q << count
-        end
-      end
+      q << "MATCH" << match.to_s if match
+      q << "COUNT" << count.to_s if count
       string_array_command(q)
     end
 
@@ -779,15 +777,13 @@ class Redis
     #
     # ```
     # redis.sscan("myset", 0)
+    # redis.sscan("myset", 0, "foo*")
+    # redis.sscan("myset", 0, "foo*", 1024)
     # ```
     def sscan(key, cursor, match = nil, count = nil)
       q = ["SSCAN", key.to_s, cursor.to_s]
-      if match
-        q << match
-        if count
-          q << count
-        end
-      end
+      q << "MATCH" << match.to_s if match
+      q << "COUNT" << count.to_s if count
       string_array_command(q)
     end
 
@@ -997,14 +993,16 @@ class Redis
     # * count - While SCAN does not provide guarantees about the number of elements returned at every iteration, it is possible to empirically adjust the behavior of SCAN using the COUNT option.
     #
     # **Return value**: Array(String), two elements, a field and a value, for every returned element of the Hash.
+
+    # ```
+    # redis.hscan("myhash", 0)
+    # redis.hscan("myhash", 0, "foo*")
+    # redis.hscan("myhash", 0, "foo*", 1024)
+    # ```
     def hscan(key, cursor, match = nil, count = nil)
       q = ["HSCAN", key.to_s, cursor.to_s]
-      if match
-        q << match
-        if count
-          q << count
-        end
-      end
+      q << "MATCH" << match.to_s if match
+      q << "COUNT" << count.to_s if count
       string_array_command(q)
     end
 
@@ -1301,15 +1299,13 @@ class Redis
     #
     # ```
     # redis.zscan("myzset", 0)
+    # redis.zscan("myzset", 0, "foo*")
+    # redis.zscan("myzset", 0, "foo*", 1024)
     # ```
     def zscan(key, cursor, match = nil, count = nil)
       q = ["ZSCAN", key.to_s, cursor.to_s]
-      if match
-        q << match
-        if count
-          q << count
-        end
-      end
+      q << "MATCH" << match.to_s if match
+      q << "COUNT" << count.to_s if count
       string_array_command(q)
     end
 


### PR DESCRIPTION
It seems SCAN with match doesn't work correctly.

#### scan(0, "foo*")
- should request: `["SCAN", "0", "MATCH", "foo*"]`

#### scan(0, "foo*", 1024)
- should request: `["SCAN", "0", "MATCH", "foo*", "COUNT", "1024"]`

Fixed it in TDD style commits :)