### PR TITLE
mset and mget

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -203,6 +203,7 @@ describe Redis do
       redis.set("foo1", "test1")
       redis.set("foo2", "test2")
       redis.mget("foo1", "foo2").should eq(["test1", "test2"])
+      redis.mget(["foo2", "foo1"]).should eq(["test2", "test1"])
     end
 
     it "#mset" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -200,6 +200,10 @@ class Redis
       string_array_command(concat(["MGET"], keys))
     end
 
+    def mget(keys : Array)
+      string_array_command(concat(["MGET"], keys))
+    end
+
     # Sets the given keys to their respective values as defined in the hash.
     #
     # **Return value**: "OK"
@@ -209,7 +213,7 @@ class Redis
     # ```
     # redis.mset({"foo1": "bar1", "foo2": "bar2"})
     # ```
-    def mset(hash)
+    def mset(hash : Hash)
       q = ["MSET"] of RedisValue
       hash.each { |key, value| q << key.to_s << value.to_s }
       string_command(q)


### PR DESCRIPTION
1. Allow mget to take a dynamic array of keys
2. Force correct type for mset argument

I was accidentally passing an array into mset, which Crystal happily allowed.