### PR TITLE
Fix SPOP with nil return from crashing.

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -564,6 +564,10 @@ describe Redis do
       #
       # redis.sadd("myset", "one", "two")
       # sort(redis.spop("myset", count: 2)).should eq(["one", "two"])
+
+
+      redis.del("myset")
+      redis.spop("myset").should eq(nil)
     end
 
     it "#sdiffstore" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -760,7 +760,7 @@ class Redis
       if count
         q << count.to_s
       end
-      string_array_or_string_command(q)
+      string_array_or_string_or_nil_command(q)
     end
 
     # When called with just the key argument, return a random element from the set value stored at key.


### PR DESCRIPTION
I think this should resolve the issue of SPOP being able to return 'nil' if the set doesn't exist. I've added a test that now passes to show this also.  I naively changed one line of code.

I hope this will resolve #21!