### PR TITLE
Implement Redis#location, which returns the server URI for this client.

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -34,10 +34,12 @@ describe Redis do
 
     it "connects to a specific database" do
       redis = Redis.new(host: "localhost", port: 6379, database: 1)
+      redis.location.should eq("redis://localhost:6379/1")
     end
 
     it "connects to Unix domain sockets" do
       redis = Redis.new(unixsocket: "/tmp/redis.sock")
+      redis.location.should eq("redis:///tmp/redis.sock/0")
       redis.ping.should eq "PONG"
     end
 

--- a/src/redis.cr
+++ b/src/redis.cr
@@ -43,6 +43,7 @@ class Redis
   # :nodoc:
   alias Request = Array(RedisValue)
 
+  getter! location : String
   @strategy : Redis::Strategy::Base
 
   # Opens a Redis connection
@@ -78,6 +79,11 @@ class Redis
   def initialize(host = "localhost", port = 6379, unixsocket = nil, password = nil, database = nil)
     @connection = Connection.new(host, port, unixsocket)
     @strategy = Redis::Strategy::SingleStatement.new(@connection)
+    @location = if unixsocket
+      "redis://#{unixsocket}/#{database ? database : 0}"
+    else
+      "redis://#{host}:#{port}/#{database ? database : 0}"
+    end
 
     if password
       auth(password)


### PR DESCRIPTION
The Ruby client [has a similar method](https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L112).  Useful for showing the current server location in a UI.

