### PR TITLE
Default argument types now must match their restriction

### DIFF
--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -1651,7 +1651,7 @@ class Redis
     # The INFO command returns information and statistics about the server.
     #
     # **Return value**: A hash with the server information
-    def info(section : String = nil)
+    def info(section : String? = nil)
       arr = ["INFO"]
       arr << section if section
       bulk = string_command(arr)


### PR DESCRIPTION
Crystal 0.20.4 will be released in a few days where type restriction about default value is strictly checked. And current master fails on 0.20.4.
https://github.com/crystal-lang/crystal/pull/3834

This PR works on both 0.20.3 and 0.20.4. Thanks.