### PR TITLE
Enable connecting Redis with url argument

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -43,30 +43,16 @@ describe Redis do
       redis.ping.should eq "PONG"
     end
 
-    context "when REDIS_URL env variable is given" do
-      Spec.before_each do
-        ENV["REDIS_URL"] = "redis://127.0.0.1"
-      end
-
-      context "and no arguments given" do
-        it "connects using given URL" do
-          redis = Redis.new
-          redis.url.should eq("redis://127.0.0.1:6379/0")
-        end
-      end
-
-      context "and arguments given" do
-        it "connects using the arguments" do
-          redis = Redis.new(host: "localhost")
-          redis.url.should eq("redis://localhost:6379/0")
-        end
+    context "when url argument is given" do
+      it "connects using given URL" do
+        redis = Redis.new(url: "redis://127.0.0.1", host: "host.to.be.ignored", port: 1234)
+        redis.url.should eq("redis://127.0.0.1:6379/0")
       end
     end
 
-    context "when REDIS_URL env variable with trailing slash is given" do
+    context "when url argument with trailing slash is given" do
       it "connects using given URL" do
-        ENV["REDIS_URL"] = "redis://127.0.0.1/"
-        redis = Redis.new
+        redis = Redis.new(url: "redis://127.0.0.1/")
         redis.url.should eq("redis://127.0.0.1:6379/0")
       end
     end
@@ -83,15 +69,18 @@ describe Redis do
         redis.close
       end
     end
-
-    Spec.after_each do
-      ENV.delete "REDIS_URL"
-    end
   end
 
   describe ".open" do
     it "connects to the Redis server, yields its block and disconnects" do
       Redis.open do |redis|
+        redis.url.should eq("redis://localhost:6379/0")
+      end
+    end
+
+    it "connects to the Redis using given url, yields its block and disconnects" do
+      Redis.open(url: "redis://127.0.0.1") do |redis|
+        redis.url.should eq("redis://127.0.0.1:6379/0")
       end
     end
   end

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -44,10 +44,22 @@ describe Redis do
     end
 
     context "when REDIS_URL env variable is given" do
-      it "connects using given URL" do
+      Spec.before_each do
         ENV["REDIS_URL"] = "redis://127.0.0.1"
-        redis = Redis.new
-        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+
+      context "and no arguments given" do
+        it "connects using given URL" do
+          redis = Redis.new
+          redis.url.should eq("redis://127.0.0.1:6379/0")
+        end
+      end
+
+      context "and arguments given" do
+        it "connects using the arguments" do
+          redis = Redis.new(host: "localhost")
+          redis.url.should eq("redis://localhost:6379/0")
+        end
       end
     end
 

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -43,6 +43,22 @@ describe Redis do
       redis.ping.should eq "PONG"
     end
 
+    context "when REDIS_URL env variable is given" do
+      it "connects using given URL" do
+        ENV["REDIS_URL"] = "redis://127.0.0.1"
+        redis = Redis.new
+        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+    end
+
+    context "when REDIS_URL env variable with trailing slash is given" do
+      it "connects using given URL" do
+        ENV["REDIS_URL"] = "redis://127.0.0.1/"
+        redis = Redis.new
+        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+    end
+
     describe "#close" do
       it "closes the connection" do
         redis = Redis.new
@@ -54,6 +70,10 @@ describe Redis do
         redis.close
         redis.close
       end
+    end
+
+    Spec.after_each do
+      ENV.delete "REDIS_URL"
     end
   end
 

--- a/src/redis.cr
+++ b/src/redis.cr
@@ -89,15 +89,17 @@ class Redis
   # redis = Redis.new
   # ...
   # ```
-  def initialize(host = "localhost", port = 6379, unixsocket = nil, password = nil, database = nil)
+  def initialize(host = nil, port = nil, unixsocket = nil, password = nil, database = nil)
     if ENV["REDIS_URL"]?
       uri = URI.parse ENV["REDIS_URL"]
-      host = uri.host.to_s
-      port = uri.port if uri.port
-      password = uri.password
+      host ||= uri.host.to_s
+      port ||= uri.port if uri.port
+      password ||= uri.password
       path = uri.path
-      database = path[1..-1] if path && path.size > 1
+      database ||= path[1..-1] if path && path.size > 1
     end
+    host ||= "localhost"
+    port ||= 6379
     @connection = Connection.new(host, port, unixsocket)
     @strategy = Redis::Strategy::SingleStatement.new(@connection)
     @url = if unixsocket
@@ -133,7 +135,7 @@ class Redis
   #   redis.incr("counter")
   # end
   # ```
-  def self.open(host = "localhost", port = 6379, unixsocket = nil, password = nil, database = nil)
+  def self.open(host = nil, port = nil, unixsocket = nil, password = nil, database = nil)
     redis = Redis.new(host, port, unixsocket, database)
     begin
       yield(redis)

--- a/src/redis.cr
+++ b/src/redis.cr
@@ -95,7 +95,8 @@ class Redis
       host = uri.host.to_s
       port = uri.port if uri.port
       password = uri.password
-      database = uri.path if uri.path != "" && uri.path != "/"
+      path = uri.path
+      database = path[1..-1] if path && path.size > 1
     end
     @connection = Connection.new(host, port, unixsocket)
     @strategy = Redis::Strategy::SingleStatement.new(@connection)


### PR DESCRIPTION
Inspired by https://github.com/redis/redis-rb, if `REDIS_URL` environment variable is set, the connection will be made using that.

I would have liked to test this better (e.g. port given vs. no port given) but it would have required mocking the connection.