### PR TITLE
Add async write and read list test

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -1325,4 +1325,19 @@ describe Redis do
       redis.get("foo").should eq(large_value)
     end
   end
+
+  describe "async list" do
+    redis = Redis.new
+
+    spawn {
+      loop {
+        sleep (rand(10) + 1).milliseconds
+        redis.lpush("mylist", rand.to_s)
+      }
+    }
+
+    it "async read list" do
+      99999.times { redis.lindex("list", 0) }
+    end
+  end
 end


### PR DESCRIPTION
will fail test with
`cast from Int64 to (String | Nil) failed, at ./crystal-redis/src/redis/command_execution/value_oriented.cr:37:9:37`