### PR TITLE
Add autoreconnection, fixed #25, #55

### DIFF
--- a/examples/test-reconnection.cr
+++ b/examples/test-reconnection.cr
@@ -1,0 +1,17 @@
+require "../src/redis"
+
+# run: redis-server --port 7777 --timeout 5
+# start/stop server in the middle
+
+r = Redis.new(host: "localhost", port: 7777)
+
+loop do
+  begin
+    r.set("test1", "a")
+    p r.get("test1")
+  rescue ex : Redis::Error
+    p ex
+  end
+
+  sleep 1.0
+end

--- a/examples/test-reconnection2.cr
+++ b/examples/test-reconnection2.cr
@@ -1,0 +1,14 @@
+require "../src/redis"
+
+# run: redis-server --port 7777 --timeout 5
+
+r = Redis.new(host: "localhost", port: 7777)
+
+r.set("test2", "a")
+p r.get("test2")
+
+# exceed timeout of redis connection
+p "wait for 7 seconds"
+sleep 7
+
+p r.get("test2")

--- a/src/redis/client.cr
+++ b/src/redis/client.cr
@@ -1,0 +1,16 @@
+class Redis::Client
+  getter connection : Redis::Connection
+  property strategy : Redis::Strategy::Base
+
+  def initialize(host, port, unixsocket, password, database, sslcxt, dns_timeout, connect_timeout)
+    @connection = Connection.new(host, port, unixsocket, sslcxt, dns_timeout, connect_timeout)
+    @strategy = Redis::Strategy::SingleStatement.new(@connection)
+
+    @strategy.command(["AUTH", password]) if password
+    @strategy.command(["SELECT", database.to_s]) if database
+  end
+
+  def close
+    @connection.close
+  end
+end

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -1561,7 +1561,7 @@ class Redis
       # Allow the caller to populate the subscription with his callbacks.
       callback_setup_block.call(subscription)
 
-      @strategy = Redis::Strategy::SubscriptionLoop.new(@connection, subscription)
+      client.strategy = Redis::Strategy::SubscriptionLoop.new(client.connection, subscription)
 
       subscribe(*channels)
     end
@@ -1592,7 +1592,7 @@ class Redis
       # Allow the caller to populate the subscription with his callbacks.
       callback_setup_block.call(subscription)
 
-      @strategy = Redis::Strategy::SubscriptionLoop.new(@connection, subscription)
+      client.strategy = Redis::Strategy::SubscriptionLoop.new(client.connection, subscription)
 
       psubscribe(*channel_patterns)
     end
@@ -1608,7 +1608,7 @@ class Redis
     end
 
     private def already_in_subscription_loop?
-      @strategy.is_a? Redis::Strategy::SubscriptionLoop
+      client.strategy.is_a? Redis::Strategy::SubscriptionLoop
     end
 
     # Unsubscribes the client from the given channels, or from all of them if none is given.

--- a/src/redis/error.cr
+++ b/src/redis/error.cr
@@ -1,18 +1,9 @@
 # Exception for errors that Redis returns.
 class Redis::Error < Exception
-  def initialize(s)
-    super("RedisError: #{s}")
-  end
-end
-
-class Redis::DisconnectedError < Redis::Error
-  def initialize
-    super("Disconnected")
-  end
 end
 
 class Redis::ConnectionError < Redis::Error
-  def initialize(s)
-    super(s)
-  end
+end
+
+class Redis::CannotConnectError < Redis::ConnectionError
 end

--- a/src/redis/socket_wrapper.cr
+++ b/src/redis/socket_wrapper.cr
@@ -1,0 +1,29 @@
+struct SocketWrapper
+  def initialize(@socket : TCPSocket | UNIXSocket | OpenSSL::SSL::Socket::Client)
+    @connected = true
+  end
+
+  def self.new
+    self.new(yield)
+  rescue ex : IO::Timeout | Errno | Socket::Error | OpenSSL::Error
+    raise Redis::CannotConnectError.new("#{ex.class}: #{ex.message}")
+  end
+
+  macro method_missing(call)
+    catch_errors { @socket.{{call}} }
+  end
+
+  private def catch_errors
+    yield
+  rescue ex : Errno | IO::Error | IO::Timeout | OpenSSL::Error
+    raise Redis::ConnectionError.new("#{ex.class}: #{ex.message}")
+  end
+
+  def close
+    if @connected
+      @connected = false
+      @socket.close
+    end
+  rescue Errno
+  end
+end


### PR DESCRIPTION
btw, maybe add option to reconnect or not?

# Fixed 

* Fixed #55, catch all possible socket/connection errors and
  raise Redis::ConnectionError.
* Fixed #25, when client execute command and get Redis::ConnectionError,
  it reconnect to redis server and reexecute last command.
* Error connection to redis server now raises Redis::CannotConnectError.
* Redis::DisconnectedError replaced with Redis::ConnectionError.
* SocketWrapper is class that wrap all methods to socket with catching all kind of errors.

# test-reconnection.cr 
was
```
"a"
"a"
"a"
Error reading socket: Connection reset by peer (Errno)
  from /usr/local/Cellar/crystal-lang/0.24.2_1/src/socket.cr:53:9 in 'unbuffered_read'
  from /usr/local/Cellar/crystal-lang/0.24.2_1/src/io/buffered.cr:206:5 in 'fill_buffer'
  from /usr/local/Cellar/crystal-lang/0.24.2_1/src/io/buffered.cr:82:7 in 'peek'
  from /usr/local/Cellar/crystal-lang/0.24.2_1/src/io.cr:322:28 in 'read_char_with_bytesize'
  from /usr/local/Cellar/crystal-lang/0.24.2_1/src/io.cr:315:12 in 'read_char'
  from src/redis/connection.cr:95:12 in 'receive'
```

became
```
"a"
"a"
"a"
#<Redis::CannotConnectError:Errno: Error connecting to 'localhost:7777': Connection refused>
"a"
"a"
```

# test-reconnection2.cr 
was
```
"a"
"wait for 7 seconds"
RedisError: Disconnected (Redis::DisconnectedError)
  from src/redis/connection.cr:0:7 in 'receive_line'
  from src/redis/connection.cr:96:5 in 'receive'
  from src/redis/strategy/single_statement.cr:12:5 in 'command'
  from src/redis.cr:239:5 in 'command'
```

became
```
"a"
"wait for 7 seconds"
"a"
```
