### PR TITLE
Add command timeout

### DIFF
--- a/src/redis/client.cr
+++ b/src/redis/client.cr
@@ -2,8 +2,8 @@ class Redis::Client
   getter connection : Redis::Connection
   property strategy : Redis::Strategy::Base
 
-  def initialize(host, port, unixsocket, password, database, sslcxt, dns_timeout, connect_timeout)
-    @connection = Connection.new(host, port, unixsocket, sslcxt, dns_timeout, connect_timeout)
+  def initialize(host, port, unixsocket, password, database, sslcxt, dns_timeout, connect_timeout, command_timeout)
+    @connection = Connection.new(host, port, unixsocket, sslcxt, dns_timeout, connect_timeout, command_timeout)
     @strategy = Redis::Strategy::SingleStatement.new(@connection)
 
     @strategy.command(["AUTH", password]) if password

--- a/src/redis/error.cr
+++ b/src/redis/error.cr
@@ -13,3 +13,7 @@ end
 # Raised when the connection to the Redis server is lost.
 class Redis::ConnectionLostError < Redis::ConnectionError
 end
+
+# Errors that occur on a command execute timeout.
+class Redis::CommandTimeoutError < Redis::Error
+end

--- a/src/redis/socket_wrapper.cr
+++ b/src/redis/socket_wrapper.cr
@@ -1,7 +1,7 @@
 # Wraps an open socket connection.
 #
 # The purpose is to be able to convert all exceptions to Redis:Error's.
-struct SocketWrapper
+struct Redis::SocketWrapper
   def initialize(@socket : TCPSocket | UNIXSocket | OpenSSL::SSL::Socket::Client)
     @connected = true
   end
@@ -18,8 +18,10 @@ struct SocketWrapper
 
   private def catch_errors
     yield
-  rescue ex : Errno | IO::Error | IO::Timeout | OpenSSL::Error
+  rescue ex : Errno | IO::Error | OpenSSL::Error
     raise Redis::ConnectionLostError.new("#{ex.class}: #{ex.message}")
+  rescue ex : IO::Timeout
+    raise Redis::CommandTimeoutError.new("Command timed out")
   end
 
   def close

--- a/test/test-timeout.cr
+++ b/test/test-timeout.cr
@@ -1,0 +1,9 @@
+require "../src/redis"
+
+# This program tests command timeout.
+#
+# run: nc -l 7778
+
+r = Redis.new(host: "localhost", port: 7778, timeout: 1.second)
+
+r.set("test3", "a")


### PR DESCRIPTION
redis-rb have this option, i also add it.
This is useful when redis-server blocked by long executed command (or dump) (sometimes this happens), and client cannot wait for long. It just throw TimeoutError, and i also remove this exception from reconection, this should only close connection and raise TimeoutError. 