### PR TITLE
convert select() to no-op if the current database is the same as target one

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -263,6 +263,33 @@ describe Redis do
       redis.select(2)
       redis.get("test_database").should eq "2"
     end
+    it "can do nothing if current database is the same as target one" do
+      redis1 = Redis.new
+      redis1.select(2)
+      ch1 = Channel(String).new
+      spawn do
+        redis1.select(2)
+        ch1.send("hello")
+      end
+
+      spawn do
+        ch1.send("bye")
+      end
+	  ch1.receive.should eq "hello"
+	  
+      redis2 = Redis.new
+      redis2.select(2)
+      ch2 = Channel(String).new
+      spawn do
+        redis2.select(1)
+        ch2.send("hello")
+      end
+
+      spawn do
+        ch2.send("bye")
+      end
+	  ch2.receive.should eq "bye"
+    end    
   end
 
   describe "strings" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -85,7 +85,15 @@ class Redis
     #
     # **Return value**: "OK"
     def select(database_number)
-      string_command(["SELECT", database_number.to_s])
+      if database_number && database_number != @database
+      	res = string_command(["SELECT", database_number.to_s])
+      	@database = database_number
+      	res
+	  elsif ! database_number
+	  	raise Redis::Error.new("ERR database number could not be Nil")
+	  else
+	  	"OK"
+	  end
     end
 
     # Renames old_key to newkey.


### PR DESCRIPTION
select() with the same database number as the already selected one leads to no exchange with the Redis server
