### PR TITLE
Fix string_or_nil_command to accept Null Array too

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -594,6 +594,10 @@ describe Redis do
       redis.brpoplpush("source", "destination", 0)
       redis.lrange("source", 0, 4).should eq(["a", "b"])
       redis.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
+
+      # timeout test (#68)
+      redis.del("source")
+      redis.brpoplpush("source", "destination", 1).should eq(nil)
     end
   end
 

--- a/src/redis/command_execution/value_oriented.cr
+++ b/src/redis/command_execution/value_oriented.cr
@@ -34,7 +34,9 @@ class Redis
       # Executes a Redis command and casts the response to the correct type.
       # This is an internal method.
       def string_or_nil_command(request : Request) : String?
-        command(request).as(String?)
+        res = command(request)
+        res = nil if res.is_a?(Array) && res.empty? # "*-1\r\n"
+        res.as(String?)
       end
 
       # Executes a Redis command and casts the response to the correct type.


### PR DESCRIPTION
Redis returns `nil` in two formats as written in https://redis.io/topics/protocol .

- a) Null Bulk String ( `"$-1\r\n"` )
- b) Null Array ( `"*-1\r\n"` )

In current master, `string_or_nil_command` accepts only the former pattern.
And it will occur errors like #68 when the server returns `nil` in the latter pattern .
This PR accepts both patterns.

Best regards,