### PR TITLE
Fix issue #84 | Fix psubscribe on pooled client

### DIFF
--- a/src/redis/pooled_client.cr
+++ b/src/redis/pooled_client.cr
@@ -57,6 +57,6 @@ class Redis::PooledClient
   end
 
   def psubscribe(*channel_patterns, &callback_setup_block : Redis::Subscription ->)
-    with_pool_connection &.subscribe(*channel_patterns) { |s| callback_setup_block.call(s) }
+    with_pool_connection &.psubscribe(*channel_patterns) { |s| callback_setup_block.call(s) }
   end
 end


### PR DESCRIPTION
The pooled Redis client is using the wrong method on the psubscribe method which results in a wrong subscription.
Fixing by adding one character.

Reference [https://github.com/stefanwille/crystal-redis/issues/84](https://github.com/stefanwille/crystal-redis/issues/84)