### PR TITLE
result of eval/evalsha can be not only array, integers and strings are acceptable too

### DIFF
--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -1478,7 +1478,7 @@ class Redis
     # redis.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", ["key1", "key2"], ["first art", "second arg"])
     # ```
     def eval(script : String, keys = [] of RedisValue, args = [] of RedisValue)
-      string_array_command(concat(["EVAL", script, keys.size.to_s], keys, args))
+      string_array_or_integer_command(concat(["EVAL", script, keys.size.to_s], keys, args))
     end
 
     # EVAL and EVALSHA are used to evaluate scripts using the Lua interpreter
@@ -1486,7 +1486,7 @@ class Redis
     #
     # **Return value**: Array(String), depends on the executed script
     def evalsha(sha1, keys = [] of RedisValue, args = [] of RedisValue)
-      string_array_command(concat(["EVALSHA", sha1.to_s, keys.size.to_s], keys, args))
+      string_array_or_integer_command(concat(["EVALSHA", sha1.to_s, keys.size.to_s], keys, args))
     end
 
     # Load a script into the scripts cache, without executing it.


### PR DESCRIPTION
But IMHO for quick and dirty solution replacing string_array_command by string_array_or_integer_command is also acceptable.