### PR TITLE
Use TimeoutError and avoid Errno on Crystal 0.34

### DIFF
--- a/src/redis/pooled_client.cr
+++ b/src/redis/pooled_client.cr
@@ -37,20 +37,37 @@ class Redis::PooledClient
     with_pool_connection { |conn| conn.{{call}} }
   end
 
-  # Executes the given block, passing it a Redis client from the connection pool.
-  private def with_pool_connection
-    conn = begin
-      @pool.checkout
-    rescue IO::Timeout
-      raise Redis::PoolTimeoutError.new("No free connection (used #{@pool.size} of #{@pool.capacity}) after timeout of #{@pool.timeout}s")
-    end
+  {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
+    # Executes the given block, passing it a Redis client from the connection pool.
+    private def with_pool_connection
+      conn = begin
+        @pool.checkout
+      rescue IO::TimeoutError
+        raise Redis::PoolTimeoutError.new("No free connection (used #{@pool.size} of #{@pool.capacity}) after timeout of #{@pool.timeout}s")
+      end
 
-    begin
-      yield(conn)
-    ensure
-      @pool.checkin(conn)
+      begin
+        yield(conn)
+      ensure
+        @pool.checkin(conn)
+      end
     end
-  end
+  {% else %}
+    # Executes the given block, passing it a Redis client from the connection pool.
+    private def with_pool_connection
+      conn = begin
+        @pool.checkout
+      rescue IO::Timeout
+        raise Redis::PoolTimeoutError.new("No free connection (used #{@pool.size} of #{@pool.capacity}) after timeout of #{@pool.timeout}s")
+      end
+
+      begin
+        yield(conn)
+      ensure
+        @pool.checkin(conn)
+      end
+    end
+  {% end %}
 
   def subscribe(*channels, &callback_setup_block : Redis::Subscription ->)
     with_pool_connection &.subscribe(*channels) { |s| callback_setup_block.call(s) }

--- a/src/redis/socket_wrapper.cr
+++ b/src/redis/socket_wrapper.cr
@@ -6,29 +6,57 @@ struct Redis::SocketWrapper
     @connected = true
   end
 
-  def self.new
-    self.new(yield)
-  rescue ex : IO::Timeout | Errno | Socket::Error | OpenSSL::Error
-    raise Redis::CannotConnectError.new("#{ex.class}: #{ex.message}")
-  end
+  {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
+    def self.new
+      self.new(yield)
+    rescue ex : IO::TimeoutError | Socket::Error | OpenSSL::Error
+      raise Redis::CannotConnectError.new("#{ex.class}: #{ex.message}")
+    end
+  {% else %}
+    def self.new
+      self.new(yield)
+    rescue ex : IO::Timeout | Errno | Socket::Error | OpenSSL::Error
+      raise Redis::CannotConnectError.new("#{ex.class}: #{ex.message}")
+    end
+  {% end %}
 
   macro method_missing(call)
     catch_errors { @socket.{{call}} }
   end
 
-  private def catch_errors
-    yield
-  rescue ex : Errno | IO::Error | OpenSSL::Error
-    raise Redis::ConnectionLostError.new("#{ex.class}: #{ex.message}")
-  rescue ex : IO::Timeout
-    raise Redis::CommandTimeoutError.new("Command timed out")
-  end
-
-  def close
-    if @connected
-      @connected = false
-      @socket.close
+  {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
+    private def catch_errors
+      yield
+    rescue ex : IO::Error | OpenSSL::Error
+      raise Redis::ConnectionLostError.new("#{ex.class}: #{ex.message}")
+    rescue ex : IO::TimeoutError
+      raise Redis::CommandTimeoutError.new("Command timed out")
     end
-  rescue Errno
-  end
+  {% else %}
+    private def catch_errors
+      yield
+    rescue ex : Errno | IO::Error | OpenSSL::Error
+      raise Redis::ConnectionLostError.new("#{ex.class}: #{ex.message}")
+    rescue ex : IO::Timeout
+      raise Redis::CommandTimeoutError.new("Command timed out")
+    end
+  {% end %}
+
+  {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
+    def close
+      if @connected
+        @connected = false
+        @socket.close
+      end
+    rescue Socket::Error
+    end
+  {% else %}
+    def close
+      if @connected
+        @connected = false
+        @socket.close
+      end
+    rescue Errno
+    end
+  {% end %}
 end


### PR DESCRIPTION
This updates support for Crystal 0.34.0 without dropping previous Crystal releases.

If that is not wanted, the macro compare_versions can be removed.