### PR TITLE
Allows `#del` to receive a `Array(RedisValue)`.

### DIFF
--- a/spec/redis_namespace_spec.cr
+++ b/spec/redis_namespace_spec.cr
@@ -157,6 +157,11 @@ describe Redis do
 
       redis.mset({"foo1" => "bar1", "foo2" => "bar2"})
       redis.del(["foo1", "foo2"]).should eq(2)
+
+      redis.set("namespaced::key", 2)
+      list_of_keys = redis.keys("namespaced::*")
+      list_of_keys.should eq(["namespaced::key"])
+      redis.del(list_of_keys)
     end
 
     it "converts keys to strings" do

--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -157,6 +157,11 @@ describe Redis do
 
       redis.mset({"foo1" => "bar1", "foo2" => "bar2"})
       redis.del(["foo1", "foo2"]).should eq(2)
+
+      redis.set("namespaced::key", 2)
+      list_of_keys = redis.keys("namespaced::*")
+      list_of_keys.should eq(["namespaced::key"])
+      redis.del(list_of_keys)
     end
 
     it "converts keys to strings" do
@@ -195,6 +200,7 @@ describe Redis do
     it "#keys" do
       redis.set("callmemaybe", 1)
       redis.keys("callmemaybe").should eq(["callmemaybe"])
+      redis.del("callmemaybe")
     end
 
     describe "#sort" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -1922,7 +1922,7 @@ class Redis
       key.to_s.gsub(namespaced(""), "").as(RedisValue)
     end
 
-    private def array_without_namespace(keys : (Array(Redis::RedisValue) | Int32 | Int64 | String | Nil))
+    private def array_without_namespace(keys : RedisValue)
       return keys unless keys.is_a?(Array(RedisValue))
 
       keys.map { |key| without_namespace("#{key}") }

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -561,7 +561,7 @@ class Redis
 
     # Returns all keys matching pattern.
     #
-    # **Return value**: Array(String), array of keys matching pattern.
+    # **Return value**: Array(RediSValue), array of keys matching pattern.
     #
     # Example:
     #
@@ -1908,11 +1908,11 @@ class Redis
       destination
     end
 
-    private def namespaced(keys : (Array(String) | Tuple(String, String)))
-      keys.map { |key| namespaced(key) }
+    private def namespaced(keys : Array(RedisValue) | Tuple(String, String))
+      keys.map { |key| namespaced(key.as(String)) }
     end
 
-    private def namespaced(key : (String | Symbol | Int32))
+    private def namespaced(key : String | Symbol | Int32)
       return key.to_s if @namespace == ""
 
       [@namespace, key.to_s].join("::")


### PR DESCRIPTION
This PR is for allowing the method `#del` to receive an `Array(RedisValue)` and perform the deletes properly.

Issue:

When performing a search with the method `#keys`, it returns a list of keys as `Array(RedisValue)` and when trying to pass the returned array to the method `#del` it fails. 

On the issue #100 I mentioned about the changing the return of the methods keys, but at looking into the API of the lib, it did not make sense as the issue was on a private method that required a simple overload and a internal casting of the keys to `String` as per redis implementation, the keys are binary-safe strings.

This PR fixes #100 