### PR TITLE
fix blpop, brpop when no data

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -580,6 +580,12 @@ describe Redis do
       redis.blpop(["myotherlist", "mylist"], 1).should eq(["mylist", "hello"])
     end
 
+    it "#blpop with no data, should not raise" do
+      redis.del("mylist")
+      redis.del("myotherlist")
+      redis.blpop(["myotherlist", "mylist"], 1).should eq([] of String)
+    end
+
     it "#ltrim" do
       redis.del("mylist")
       redis.rpush("mylist", "hello", "good", "world")
@@ -595,6 +601,12 @@ describe Redis do
 
       redis.del("mylist")
       redis.brpop(["mylist"], 1).should eq([] of String)
+    end
+
+    it "#brpop with no data, should not raise" do
+      redis.del("mylist")
+      redis.del("myotherlist")
+      redis.brpop(["myotherlist", "mylist"], 1).should eq([] of String)
     end
 
     it "#rpoplpush" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -914,8 +914,7 @@ class Redis
 
       return result unless result
 
-      result[0] = without_namespace("#{result.first}")
-      result
+      result.map { |r| without_namespace(r.to_s) }
     end
 
     # BRPOP is a blocking list pop primitive.
@@ -943,8 +942,7 @@ class Redis
 
       return result if result.nil? || result.empty?
 
-      result[0] = without_namespace("#{result.first}")
-      result
+      result.map { |r| without_namespace(r.to_s) }
     end
 
     # Atomically returns and removes the last element (tail) of the list stored at source,


### PR DESCRIPTION
commit d5587eb8c70c8cf1d4e4d3f862ade2ed533ad50c break behavior of blpop, when there is no data it raises `Empty enumerable (Enumerable::EmptyError)`, because of `result.first`. Fix it to return empty array, as it was before.