### PR TITLE
Multi key update with HSET

### DIFF
--- a/spec/redis_spec.cr
+++ b/spec/redis_spec.cr
@@ -779,6 +779,9 @@ describe Redis do
       redis.del("myhash")
       redis.hset("myhash", "a", "434")
       redis.hget("myhash", "a").should eq("434")
+
+      redis.hset("myhash", {"a" => "434", "b" => "435"})
+      redis.hget("myhash", "b").should eq("435")
     end
 
     it "#hgetall" do

--- a/src/redis/commands.cr
+++ b/src/redis/commands.cr
@@ -995,6 +995,21 @@ class Redis
       integer_command(["HSET", namespaced(key), field.to_s, value.to_s])
     end
 
+    # Sets fields in the hash stored at keys to values.
+    #
+    # **Return value**: Integer, specifically:
+    # * 1 if field is a new fields in the hash and value was set.
+    # * 0 if fields already exists in the hash and the value was updated.
+    #
+    # Example:
+    #
+    # ```
+    # redis.hset("myhash", {"a" => "434", "b" => "435"})
+    # ```
+    def hset(key, hash : Hash)
+      integer_command(["HSET", namespaced(key)] + hash.to_a.map { |t| t.to_a }.flatten)
+    end
+
     # Returns the value associated with field in the hash stored at key.
     #
     # **Return value**: String, the value associated with field, or nil


### PR DESCRIPTION
Redis allows multiple keys to bet using HSET, This change allows the
hash to be set using a crystal hash
