### PR TITLE
2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.8.0
-* **breaking-change**: `keys` return now Array(String) instead of Array(RedisValue), (#100, #101, #105)
 * **breaking-change**: `zadd` return Int64 | String (instead of Int64)
 * **breaking-change**: `hgetall` now returns Hash(String, String) instead of Array(String) (#4, #77)
 * **breaking-change**: `hscan` now returns Hash(String, String) instead of Array(String) as second result
+* Fix `del` to receive Array(RedisValue) (#100, #101, #105)
 * Add `hset` method with Hash argument (#113, thanks @tachyons)
 * Fix `brpoplpush` to work with namespaces
 * Add `geosearch` method (#115, thanks @yrgoldteeth)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.8.0
-* **breaking-change**: `zadd` return Int64 | String (instead of Int64)
+* **breaking-change**: `zadd` return Int64 | String (instead of Int64) (#112)
 * **breaking-change**: `hgetall` now returns Hash(String, String) instead of Array(String) (#4, #77)
 * **breaking-change**: `hscan` now returns Hash(String, String) instead of Array(String) as second result
 * Fix `del` to receive Array(RedisValue) (#100, #101, #105)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.8.0
 * **breaking-change**: `keys` return now Array(String) instead of Array(RedisValue), (#100, #101, #105)
 * **breaking-change**: `zadd` return Int64 | String (instead of Int64)
-* **breaking-change**: `hgetall` now returns Hash(String, String) instead of Array(String)
+* **breaking-change**: `hgetall` now returns Hash(String, String) instead of Array(String) (#4, #77)
 * **breaking-change**: `hscan` now returns Hash(String, String) instead of Array(String) as second result
 * Add `hset` method with Hash argument (#113, thanks @tachyons)
 * Fix `brpoplpush` to work with namespaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,15 @@
-Please see https://github.com/stefanwille/crystal-redis/releases
+## 2.8.0
+* **breaking-change**: `keys` return now Array(String) instead of Array(RedisValue), (#100, #101, #105)
+* **breaking-change**: `zadd` return Int64 | String (instead of Int64)
+* **breaking-change**: `hgetall` now returns Hash(String, String) instead of Array(String)
+* **breaking-change**: `hscan` now returns Hash(String, String) instead of Array(String) as second result
+* Add `hset` method with Hash argument (#113, thanks @tachyons)
+* Fix `brpoplpush` to work with namespaces
+* Add `geosearch` method (#115, thanks @yrgoldteeth)
+* Unsubscribe now reset connection, and can be used as usual (#106, #108)
+* Add options for `zadd`: nx, xx, ch, incr (#112, thanks @noellabo)
+* Fixed `ping` command in subscribe (#28)
+
+## Previous versions:
+* Please see https://github.com/stefanwille/crystal-redis/releases
 


### PR DESCRIPTION
This is 2.8.0 release, @stefanwille @robacarp, can you look at changes?
Travis not works, specs now here, in github actions: https://github.com/stefanwille/crystal-redis/runs/2991622242?check_suite_focus=true (only failing spec with unixsocket, waiting actions to fix it).