### PR TITLE
Bump Version to 2.8.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: redis
-version: 2.7.0
+version: 2.8.0
 
 authors:
   - Stefan Wille <nospam-post@nospam-stefanwille-dot-com>


### PR DESCRIPTION
## Why this change

Currently the latest tag release is `v2.8.0` and when performing `shards install/update` it cannot find this version. 

## Side Effects

 Can install version `v2.8.0` after running `shards install/update`