### PR TITLE
Test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         stable: [true]
         crystal:
-          - 0.34.0
-          - 0.35.1
           - 0.36.1
           - 1.0.0
           - 1.1.1

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 2.8.2
 authors:
   - Stefan Wille <nospam-post@nospam-stefanwille-dot-com>
 
-crystal: ">= 0.34.0, < 2.0.0"
+crystal: ">= 0.36.1"
 
 dependencies:
   pool:


### PR DESCRIPTION
Creates a test matrix with the range given in the `shard.yml`.

This was done to show an issue with type annotations introduced in the `1.2.0` release candidate.

It also looks like this has unearthed some issues against crystal versions in the `>= 0.34.0, <= 0.35.1` range