### PR TITLE
concurrency issue with -Dpreview_mt

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,4 +8,5 @@ crystal: ">= 0.36.1"
 
 dependencies:
   pool:
-    github: ysbaddaden/pool
+    github: pbrumm/pool
+    branch: bug/crash_in_high_concurrency_due_to_object_moves


### PR DESCRIPTION
really the fix is within the pool lib but just wanted to give some visibility.

if using -Dpreview_mt and high concurrency around redis checkin and checkout for the pooled connection.   There are chances of hitting some mem crashes and inconsistencies around array access

also objects like arrays and hashes that are accessed outside of mutex will sometimes move in mem to resize and that can mess things up as well.

this change fixed my inconsistencies and crashes around multi threading.

you shouldn't merge directly as I switch the shard deps which will mess up peoples builds.

I am going to submit into the pool repo as well.