### PR TITLE
Fix `timeout` type for >= 0.3.0 `pool` compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,3 +9,4 @@ crystal: ">= 0.36.1"
 dependencies:
   pool:
     github: ysbaddaden/pool
+    version: ">= 0.3.0"

--- a/spec/redis_pooled_client_spec.cr
+++ b/spec/redis_pooled_client_spec.cr
@@ -13,7 +13,7 @@ describe Redis::PooledClient do
       client.pool.checkout
       client.pool.checkout
 
-      expect_raises(Redis::PoolTimeoutError, "No free connection (used 2 of 2) after timeout of 0.01s") do
+      expect_raises(Redis::PoolTimeoutError, "No free connection (used 2 of 2) after timeout of 00:00:00.010000000s") do
         client.get("bla")
       end
     end

--- a/src/redis/pooled_client.cr
+++ b/src/redis/pooled_client.cr
@@ -27,7 +27,7 @@ class Redis::PooledClient
   # * pool_size - the number of `Redis` to hold in the connection pool.
   # * pool_timeout - the time to wait for a `Redis` instance to become available from the pool before dying with `Redis::PoolTimeoutError`.
   def initialize(*args, pool_size = 5, pool_timeout = 5.0, **args2)
-    @pool = ConnectionPool(Redis).new(capacity: pool_size, timeout: pool_timeout) do
+    @pool = ConnectionPool(Redis).new(capacity: pool_size, timeout: pool_timeout.seconds) do
       Redis.new(*args, **args2)
     end
   end


### PR DESCRIPTION
The scheduled specs appear to be broken at the moment due to some changes in the `pool` shard with [version 0.3.0](https://github.com/ysbaddaden/pool/blob/main/CHANGELOG.md#v030---feb-8-2023) which ultimately addressed some concurrency issues as reported in https://github.com/stefanwille/crystal-redis/pull/132.

Here is an [example build failure](https://github.com/stefanwille/crystal-redis/actions/runs/4272433122) along with the error messages:

```
expected argument 'timeout' to 'ConnectionPool(Redis).new' to be Time::Span, not Float64
```

In `pool` [0.3.0](https://github.com/ysbaddaden/pool/compare/v0.2.4...v0.3.0) the float `timeout` initializer was deprecated in favor of a Time::Span. I would not have thought this would break the build since it is only deprecated (and not removed), but maybe I'm not understanding how deprecations work in Crystal.

Regardless, this PR changes the float value to a Time::Span to conform with the new initializer. I also marked the `pool` shard as dependent on >= 0.3.0. Let me know if that is undesirable.